### PR TITLE
build: update Python versions in workflow configurations

### DIFF
--- a/.github/workflows/check-pypi.yml
+++ b/.github/workflows/check-pypi.yml
@@ -5,11 +5,17 @@ on: workflow_dispatch
 jobs:
   install:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/setup-python@v5

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -5,11 +5,18 @@ on: workflow_dispatch
 jobs:
   check:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
This pull request includes updates to the Python version matrix in two GitHub Actions workflow files to ensure compatibility with newer Python versions.

Updates to Python version matrix:

* [`.github/workflows/check-pypi.yml`](diffhunk://#diff-4fe77b50d4c92b908422c783ed6fe815e88a87b552c398a9beff284514aa862eR8-R18): Expanded the Python version matrix to include versions 3.11, 3.12, and 3.13.
* [`.github/workflows/manual.yml`](diffhunk://#diff-546f37fac6467ab26e4179223b2906255b2376dcec04d05896317574b684a6d6R8-R19): Expanded the Python version matrix to include versions 3.9, 3.11, 3.12, and 3.13.