### PR TITLE
ci: npmの依存関係の更新スケジュールを年1回に設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "yearly"


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. It adds a yearly schedule for checking npm dependencies, in addition to the existing monthly schedule for other ecosystems.

* Added a yearly Dependabot update schedule for the `npm` package ecosystem in `.github/dependabot.yml`.