### PR TITLE
fix(dependabot): change pip update interval from monthly to yearly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "yearly"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
This pull request makes a small configuration change to the Dependabot schedule for Python dependencies. The update changes the interval for checking updates from monthly to yearly.